### PR TITLE
call activate when other tab got closed

### DIFF
--- a/lib/src/layout/tabs_group.dart
+++ b/lib/src/layout/tabs_group.dart
@@ -80,7 +80,7 @@ class TabGroupController with ChangeNotifier {
     if (_tabs.isEmpty) {
       _activeTabIndex = null;
     } else {
-      _activeTabIndex = _activeTabIndex!.clamp(0, _tabs.length - 1);
+      setActiveTab(_activeTabIndex!.clamp(0, _tabs.length - 1));
     }
 
     notifyListeners();


### PR DESCRIPTION
This PR changes the remove tab logic that when it activates another tab it now uses the internal method for that in order to have the same behavior like any other activation (e.g. notify any listeners that this tab got acitvated)