### PR TITLE
Avoid dragging single tab

### DIFF
--- a/lib/src/layout/tabs_accept_region.dart
+++ b/lib/src/layout/tabs_accept_region.dart
@@ -1,20 +1,24 @@
 import 'package:flutter/material.dart' hide Tab;
 import 'package:tabs/src/layout/tabs_column.dart';
-import 'package:tabs/src/layout/tabs_row.dart';
 import 'package:tabs/src/layout/tabs_group.dart';
 import 'package:tabs/src/layout/tabs_layout.dart';
+import 'package:tabs/src/layout/tabs_row.dart';
 import 'package:tabs/src/tab.dart';
+
+import '../../tabs.dart';
 
 class TabAcceptRegion extends StatelessWidget {
   TabAcceptRegion({
     required this.child,
     required this.original,
     required this.onReplace,
+    required this.mainController,
   });
 
   final Widget child;
   final TabsLayout original;
   final void Function(TabsLayout) onReplace;
+  final TabsController mainController;
 
   @override
   Widget build(BuildContext context) {
@@ -30,7 +34,7 @@ class TabAcceptRegion extends StatelessWidget {
               child: TabAcceptArea(
                 top: 32,
                 onAccept: (tab) {
-                  final controller = TabGroupController();
+                  final controller = TabGroupController(mainController);
                   controller.addTab(tab);
                   final group = TabsGroup(controller: controller);
                   onReplace(TabColumn(top: group, bottom: original));
@@ -43,7 +47,7 @@ class TabAcceptRegion extends StatelessWidget {
               height: constrains.maxHeight * 0.5,
               child: TabAcceptArea(
                 onAccept: (tab) {
-                  final controller = TabGroupController();
+                  final controller = TabGroupController(mainController);
                   controller.addTab(tab);
                   final group = TabsGroup(controller: controller);
                   onReplace(TabColumn(top: original, bottom: group));
@@ -58,7 +62,7 @@ class TabAcceptRegion extends StatelessWidget {
                 top: 32,
                 left: constrains.maxWidth * 0.2,
                 onAccept: (tab) {
-                  final controller = TabGroupController();
+                  final controller = TabGroupController(mainController);
                   controller.addTab(tab);
                   final group = TabsGroup(controller: controller);
                   onReplace(TabRow(left: original, right: group));
@@ -73,7 +77,7 @@ class TabAcceptRegion extends StatelessWidget {
                 top: 32,
                 right: constrains.maxWidth * 0.2,
                 onAccept: (tab) {
-                  final controller = TabGroupController();
+                  final controller = TabGroupController(mainController);
                   controller.addTab(tab);
                   final group = TabsGroup(controller: controller);
                   onReplace(TabRow(left: group, right: original));
@@ -132,9 +136,7 @@ class _TabAcceptAreaState extends State<TabAcceptArea> {
               if (mounted) {
                 setState(() => isAccepting = false);
               }
-              if (widget.onAccept != null) {
-                widget.onAccept(val);
-              }
+              widget.onAccept(val);
             },
             onWillAccept: (val) {
               if (mounted) {

--- a/lib/src/layout/tabs_column.dart
+++ b/lib/src/layout/tabs_column.dart
@@ -22,6 +22,9 @@ class TabColumn extends StatefulWidget implements TabsLayout {
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
     return 'TabColumn($top, $bottom)';
   }
+
+  @override
+  int get tabCount => top.tabCount + bottom.tabCount;
 }
 
 class _TabColumnState extends State<TabColumn> {

--- a/lib/src/layout/tabs_group.dart
+++ b/lib/src/layout/tabs_group.dart
@@ -5,12 +5,17 @@ import 'package:tabs/src/layout/tabs_accept_region.dart';
 import 'package:tabs/src/layout/tabs_group_action.dart';
 import 'package:tabs/src/layout/tabs_layout.dart';
 import 'package:tabs/src/tab.dart';
+import 'package:tabs/src/tabs_view.dart';
 import 'package:tabs/src/util/divider.dart';
 
 class TabGroupController with ChangeNotifier {
+  TabGroupController(this.mainController);
   var _tabs = <Tab>[];
+  final TabsController mainController;
 
   List<Tab> get tabs => _tabs;
+
+  bool get allowDrag => mainController.tabCount > 1;
 
   int get length => tabs.length;
 
@@ -118,6 +123,9 @@ class TabsGroup extends StatefulWidget implements TabsLayout {
 
   @override
   TabsGroupState createState() => TabsGroupState();
+
+  @override
+  int get tabCount => controller.length;
 }
 
 class TabsGroupState extends State<TabsGroup> {
@@ -149,6 +157,7 @@ class TabsGroupState extends State<TabsGroup> {
     return TabGroupProvider(
       controller: widget.controller,
       child: TabAcceptRegion(
+        mainController: widget.controller.mainController,
         original: widget,
         onReplace: (layout) {
           ReplaceListener.of(context).requestReplace(layout);
@@ -189,7 +198,7 @@ class TabsGroupState extends State<TabsGroup> {
         child: Draggable<Tab>(
           data: tab,
           childWhenDragging: Container(),
-          maxSimultaneousDrags: widget.controller.length > 1 ? 1 : 0,
+          maxSimultaneousDrags: widget.controller.allowDrag ? 1 : 0,
           child: LayoutBuilder(builder: (context, constraints) {
             lastConstraints = constraints;
             return DragTarget<Tab>(

--- a/lib/src/layout/tabs_group.dart
+++ b/lib/src/layout/tabs_group.dart
@@ -189,6 +189,7 @@ class TabsGroupState extends State<TabsGroup> {
         child: Draggable<Tab>(
           data: tab,
           childWhenDragging: Container(),
+          maxSimultaneousDrags: widget.controller.length > 1 ? 1 : 0,
           child: LayoutBuilder(builder: (context, constraints) {
             lastConstraints = constraints;
             return DragTarget<Tab>(

--- a/lib/src/layout/tabs_layout.dart
+++ b/lib/src/layout/tabs_layout.dart
@@ -1,3 +1,5 @@
 import 'package:flutter/widgets.dart';
 
-abstract class TabsLayout extends Widget {}
+abstract class TabsLayout extends Widget {
+  int get tabCount;
+}

--- a/lib/src/layout/tabs_row.dart
+++ b/lib/src/layout/tabs_row.dart
@@ -22,6 +22,9 @@ class TabRow extends StatefulWidget implements TabsLayout {
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
     return 'TabRow($left, $right)';
   }
+
+  @override
+  int get tabCount => left.tabCount + right.tabCount;
 }
 
 class _TabRowState extends State<TabRow> {

--- a/lib/src/tabs_view.dart
+++ b/lib/src/tabs_view.dart
@@ -7,6 +7,8 @@ class TabsController with ChangeNotifier {
   TabsLayout? _root;
   TabsLayout? get root => _root;
 
+  int get tabCount => _root?.tabCount ?? 0;
+
   void replaceRoot(TabsLayout? layout) {
     _root = layout;
 


### PR DESCRIPTION
This PR tries to solve a problem that a single tab can be dragged but not placed anywhere.
When dropped out of range of any viable drop zone then the tab was lost